### PR TITLE
Add debug for single-tag with children.

### DIFF
--- a/example/interfaces/go.mod
+++ b/example/interfaces/go.mod
@@ -3,7 +3,7 @@ module ex_interfaces
 go 1.24.0
 
 require (
-	github.com/rohanthewiz/element v0.4.5-0.20250519021340-bfbdd4fdd6f4 // indirect
+	github.com/rohanthewiz/element v0.5.2 // indirect
 	github.com/rohanthewiz/rweb v0.1.13-0.20250307165947-074c63d462ae // indirect
 	github.com/rohanthewiz/serr v1.2.2 // indirect
 )

--- a/example/interfaces/go.sum
+++ b/example/interfaces/go.sum
@@ -1,5 +1,7 @@
 github.com/rohanthewiz/element v0.4.5-0.20250519021340-bfbdd4fdd6f4 h1:8Me9LI/+O1ZaCq05Dy5KuABxTfzU/d8z+ecHDsXShP4=
 github.com/rohanthewiz/element v0.4.5-0.20250519021340-bfbdd4fdd6f4/go.mod h1:cA57S9UGRSaWrMmGC1M+8QCQw/y8kgODiBB0KEwIyzo=
+github.com/rohanthewiz/element v0.5.2 h1:MG0Wmpc6HvD+Pg8go2q2lL+pAX5dPaaKnO3uRp3fi6k=
+github.com/rohanthewiz/element v0.5.2/go.mod h1:cA57S9UGRSaWrMmGC1M+8QCQw/y8kgODiBB0KEwIyzo=
 github.com/rohanthewiz/rweb v0.1.13-0.20250307165947-074c63d462ae h1:CL7ksi0wR5c0/jb4Um4dZd0asg0HBPlTz0miKe7IJsU=
 github.com/rohanthewiz/rweb v0.1.13-0.20250307165947-074c63d462ae/go.mod h1:GBeM+x9dq6LY3GCQXRFNxX5sLpBBcZdsCLw39qj2PmA=
 github.com/rohanthewiz/serr v1.2.2 h1:uFQXy4Gzf0ZAfdGvUxRmHJbGcFAjYnHBL3k2HiCvgeM=

--- a/example/interfaces/main.go
+++ b/example/interfaces/main.go
@@ -36,17 +36,17 @@ func main() {
 		return ctx.WriteHTML(b.String())
 	})
 
-	s.Get("/debug-set", func(c rweb.Context) error {
+	s.Get("/debug/set", func(c rweb.Context) error {
 		element.DebugSet()
 		return c.WriteHTML("<h3>Debug mode set.</h3> <a href='/'>Home</a>")
 	})
 
-	s.Get("/debug-clear", func(c rweb.Context) error {
+	s.Get("/debug/clear", func(c rweb.Context) error {
 		element.DebugClear()
 		return c.WriteHTML("<h3>Debug mode is off.</h3> <a href='/'>Home</a>")
 	})
 
-	s.Get("/debug-show", func(c rweb.Context) error {
+	s.Get("/debug/show", func(c rweb.Context) error {
 		err := c.WriteHTML(element.DebugShow())
 		return err
 	})

--- a/helpers.go
+++ b/helpers.go
@@ -42,9 +42,9 @@ func stringlistToMap(e Element, items ...string) map[string]string {
 	if len(items)%2 != 0 {
 		issue := fmt.Sprintf(`Even number of arguments required for Element attributes.
 Args: %q dropping %q`, items, items[len(items)-1])
-		// fmt.Println(issue)
 
 		if debugMode {
+			fmt.Printf("![%s] %s\n", e.id, issue)
 			e.issues = append(e.issues, issue)
 			concerns.UpsertConcern(concernOther, e)
 		}


### PR DESCRIPTION
- Introduce additional debugging messages for single-tag validation and child rendering issues.
- Refactor debug routes from `/debug-*` to `/debug/*` for consistency.
- Add `TestRender()` example in `simple_element_example`.
- Update README with new examples and notes.