### PR TITLE
Roh/use bytes buffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ See ai_docs/ARCHITECTURE.md
 
 1. **Builder Pattern** (`builder.go`, `builder_elements.go`)
    - Central to the library's API
-   - Maintains an underlying `strings.Builder` for efficient HTML generation
+   - Maintains an underlying `bytes.Buffer` for efficient HTML generation
    - Single-pass rendering with minimal memory allocation
 
 2. **Element Structure** (`element.go`)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simply create an element and render it:
 (Please see the full examples in the example/ folder)
 
 ## How it works
-- Element maintains an underlying `strings.Builder`, to which it appends HTML as you go.
+- Element maintains an underlying `bytes.Buffer`, to which it appends HTML as you go.
 - When you call `b.P()` an opening paragraph tag is immediately added to the string builder.
 - `b.P()` returns an element.Element.
 - Elements may have children, so we don't render their closing tags as yet. This is where `R()` comes in. 

--- a/ai_docs/ARCHITECTURE.md
+++ b/ai_docs/ARCHITECTURE.md
@@ -81,7 +81,7 @@ type Element struct {
     name       string            // Tag name (div, p, span, etc.)
     id         string            // Debug-mode tracking ID
     attrs      map[string]string // Element attributes
-    sb         *strings.Builder  // Reference to builder's buffer
+    sb         *bytes.Buffer  // Reference to builder's buffer
     issues     []string          // Debug-mode issues
     function   string            // Creation context (debug)
     location   string            // File:line (debug)
@@ -102,7 +102,7 @@ The `Builder` is the primary API entry point:
 type Builder struct {
     Ele  elementFunc         // Element creation function
     Text textFunc            // Text node function
-    s    *strings.Builder    // Internal HTML accumulator
+    s    *bytes.Buffer    // Internal HTML accumulator
 }
 ```
 
@@ -163,7 +163,7 @@ The debug system (`element_debug.go`) provides runtime issue detection:
 
 ### 1. Performance
 - **Single-pass generation** - No intermediate AST or multiple passes
-- **`strings.Builder`** - Efficient string concatenation with minimal allocation
+- **`bytes.Buffer`** - Efficient string concatenation with minimal allocation
 - **No reflection** - Compile-time type safety, no runtime overhead
 
 ### 2. Developer Experience
@@ -189,7 +189,7 @@ The debug system (`element_debug.go`) provides runtime issue detection:
 
 #### 1. Builder Pool for High-Throughput Scenarios
 
-**Problem:** Each request creates a new Builder with fresh `strings.Builder` allocation.
+**Problem:** Each request creates a new Builder with fresh `bytes.Buffer` allocation.
 
 **Solution:** Add optional `sync.Pool`-based builder acquisition:
 

--- a/ai_docs/backlog/IMPLEMENTATION_PROPOSALS.md
+++ b/ai_docs/backlog/IMPLEMENTATION_PROPOSALS.md
@@ -22,7 +22,7 @@ This document expands on the improvement opportunities identified in [ARCHITECTU
 
 ### Problem Statement
 
-Every HTTP request that renders HTML creates a new `Builder`, which internally allocates a fresh `strings.Builder`. In high-traffic applications, this creates allocation pressure:
+Every HTTP request that renders HTML creates a new `Builder`, which internally allocates a fresh `bytes.Buffer`. In high-traffic applications, this creates allocation pressure:
 
 ```go
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -350,7 +350,7 @@ Update the `New()` function in `element.go`:
 ```go
 // In element.go - modify attribute handling
 
-func New(s *strings.Builder, el string, attrs ...any) Element {
+func New(s *bytes.Buffer, el string, attrs ...any) Element {
     // ... existing setup code ...
 
     s.WriteString("<")
@@ -669,7 +669,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 This causes:
 - **High TTFB** (Time To First Byte) - User sees blank screen until entire page is ready
-- **High memory usage** - Entire page held in `strings.Builder`
+- **High memory usage** - Entire page held in `bytes.Buffer`
 - **Poor perceived performance** - No progressive rendering
 
 ### Proposed Solution

--- a/builder.go
+++ b/builder.go
@@ -1,20 +1,20 @@
 package element
 
 import (
-	"strings"
+	"bytes"
 )
 
 // Builder has everything we need for building and rendering HTML
 type Builder struct {
-	Ele  elementFunc      // function for building an element
-	Text textFunc         // function for rendering literal text
-	s    *strings.Builder // accumulates our output
+	Ele  elementFunc   // function for building an element
+	Text textFunc      // function for rendering literal text
+	s    *bytes.Buffer // accumulates our output
 }
 
 // NewBuilder returns a builder for creating our HTML
 func NewBuilder() (b *Builder) {
 	b = &Builder{}
-	b.s = &strings.Builder{}
+	b.s = bytes.NewBuffer(make([]byte, 0, 256))
 
 	b.Ele = func(el string, attrPairs ...string) Element {
 		return New(b.s, el, attrPairs...)
@@ -49,7 +49,12 @@ func (b *Builder) String() string {
 	return b.s.String()
 }
 
-// Reset clears the internal strings.Builder
+// Bytes returns the accumulated buffer as bytes
+func (b *Builder) Bytes() []byte {
+	return b.s.Bytes()
+}
+
+// Reset clears the internal bytes.Buffer
 func (b *Builder) Reset() {
 	b.s.Reset()
 }

--- a/builder.go
+++ b/builder.go
@@ -25,6 +25,11 @@ func NewBuilder() (b *Builder) {
 	return
 }
 
+// B is a convenience function for NewBuilder
+func B() (b *Builder) {
+	return NewBuilder()
+}
+
 // Input / 0utput
 
 // WriteString writes directly to the string builder

--- a/builder_funcs.go
+++ b/builder_funcs.go
@@ -11,24 +11,28 @@ type elementFunc func(el string, attrPairs ...string) Element
 type textFunc func(attrPairs ...string) any
 
 // BUILDER CONVENIENCE METHODS
+// (We shouldn't have much need for these anymore as we do want to build everything from the builder to get the advantages like debugging)
 
 // Funcs is a convenience method for returning
 // the builder methods b.Ele and b.Text
-// that are used for creating elements and literal text
+// that are used for creating elements and literal text.
+// We are deprecating this. Just use the builder for all the things
 func (b *Builder) Funcs() (ele elementFunc, text textFunc) {
 	return b.Ele, b.Text
 }
 
 // Vars is a convenience method for returning
 // the builder methods b.Ele and b.Text
-// that are used for creating elements and literal text
+// that are used for creating elements and literal text.
+// We are deprecating this. Just use the builder for all the things
 func (b *Builder) Vars() (ele elementFunc, text textFunc) {
 	return b.Ele, b.Text
 }
 
 // V is a convenience method for returning
 // the builder methods b.Ele and b.Text
-// that are used for creating elements and literal text
+// that are used for creating elements and literal text.
+// We are deprecating this. Just use the builder for all the things
 func (b *Builder) V() (ele elementFunc, text textFunc) {
 	return b.Ele, b.Text
 }

--- a/element.go
+++ b/element.go
@@ -1,6 +1,7 @@
 package element
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -22,7 +23,7 @@ type Element struct {
 	attrs      map[string]string
 	function   string // function in which the element is created
 	location   string // file:line_nbr of the element creation
-	sb         *strings.Builder
+	sb         *bytes.Buffer
 	issues     []string // issues can hold any issues with the element
 }
 
@@ -31,7 +32,7 @@ func (el Element) Name() string {
 }
 
 // New creates a new element
-func New(s *strings.Builder, el string, attrs ...string) (e Element) {
+func New(s *bytes.Buffer, el string, attrs ...string) (e Element) {
 	if s == nil {
 		fmt.Println("Please supply a pointer to a string builder to element.New():", el)
 	}
@@ -72,7 +73,7 @@ func (el Element) HasAttribute(key, value string) bool {
 }
 
 // Text is an element core function which creates a new text element in the string builder
-func Text(s *strings.Builder, texts ...string) (x any) {
+func Text(s *bytes.Buffer, texts ...string) (x any) {
 	if s == nil {
 		fmt.Println("Please supply a pointer to a string builder to element.Text()")
 	}

--- a/element_debug.go
+++ b/element_debug.go
@@ -1,6 +1,7 @@
 package element
 
 import (
+	"bytes"
 	_ "embed"
 	"fmt"
 	"strings"
@@ -174,7 +175,7 @@ func DebugShow(opts ...DebugOptions) (out string) {
 		b, _, _ := Vars()
 
 		// Build markdown content
-		var markdownContent strings.Builder
+		var markdownContent bytes.Buffer
 		markdownContent.WriteString("## Element Concerns\n\n")
 		markdownContent.WriteString(fmt.Sprintf("Total issues: %d\n\n", len(dedupedConcerns)))
 		markdownContent.WriteString("| Key | Details | Issues |\n")

--- a/element_funcs.go
+++ b/element_funcs.go
@@ -2,13 +2,15 @@ package element
 
 // ELEMENT CONVENIENCE FUNCTIONS
 
-// Vars returns a builder plus it's convenience methods for creating elements and text
+// Vars returns a builder plus it's convenience methods for creating elements and text.
+// We are deprecating this. Just use the builder for all the things, so prefer NewBuilder() or B()
 func Vars() (b *Builder, e elementFunc, t textFunc) {
 	b = NewBuilder()
 	return b, b.Ele, b.Text
 }
 
 // V is a short form of Vars which returns a builder and it's convenience methods
+// We are deprecating this. Just use the builder for all the things, so prefer NewBuilder() or B()
 func V() (b *Builder, e elementFunc, t textFunc) {
 	return Vars()
 }

--- a/element_test.go
+++ b/element_test.go
@@ -1,6 +1,7 @@
 package element
 
 import (
+	"bytes"
 	"regexp"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 // Maybe just to use a single attribute pair or test only the length of the output if multiple attributes are required
 
 func TestRender(t *testing.T) {
-	s := &strings.Builder{}
+	s := &bytes.Buffer{}
 
 	New(s, "span").R()
 	want := `<span.*></span>`
@@ -114,7 +115,7 @@ func TestElement_F(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sb := &strings.Builder{}
+			sb := &bytes.Buffer{}
 			el := New(sb, "div")
 			el.F(tt.format, tt.args...)
 
@@ -131,7 +132,7 @@ func TestElement_F(t *testing.T) {
 /*func TestFor(t *testing.T) {
 	var testAnimals = []string{"cat", "mouse", "dog"}
 
-	s := &strings.Builder{}
+	s := &bytes.Buffer{}
 
 	// Div with text and element children
 	New(s, "div", "id", "container", "class", "active").R(

--- a/examples/builder_pool/README.md
+++ b/examples/builder_pool/README.md
@@ -78,10 +78,10 @@ Use regular `NewBuilder()` when:
 
 The builder pool provides:
 
-1. **Reduced allocations** - Reuses `Builder` and `strings.Builder` instances
+1. **Reduced allocations** - Reuses `Builder` and `bytes.Buffer` instances
 2. **Lower GC pressure** - Fewer objects for the garbage collector to track
 3. **More stable latency** - Fewer GC pauses means more consistent response times
-4. **Capacity reuse** - The internal `strings.Builder` retains its grown capacity
+4. **Capacity reuse** - The internal `bytes.Buffer` retains its grown capacity
 
 ### Benchmark Results
 
@@ -92,7 +92,7 @@ BenchmarkBuilderAllocation-16    56412    19684 ns/op   5541 B/op   80 allocs/op
 BenchmarkBuilderPooled-16        62487    19716 ns/op   5457 B/op   76 allocs/op
 ```
 
-The pooled version saves 4 allocations per operation (the `Builder` struct and `strings.Builder`).
+The pooled version saves 4 allocations per operation (the `Builder` struct and `bytes.Buffer`).
 
 ## Load Testing
 

--- a/examples/builder_pool/main.go
+++ b/examples/builder_pool/main.go
@@ -144,7 +144,7 @@ func renderFeatureList(b *element.Builder) any {
 			b.Li().T("Reduced memory allocations per request"),
 			b.Li().T("Lower GC pressure in high-throughput scenarios"),
 			b.Li().T("More stable latency (fewer GC pauses)"),
-			b.Li().T("Reuses strings.Builder capacity"),
+			b.Li().T("Reuses bytes.Buffer capacity"),
 			b.Li().T("Thread-safe for concurrent use"),
 		),
 	)

--- a/examples/interfaces/main.go
+++ b/examples/interfaces/main.go
@@ -17,11 +17,10 @@ func main() {
 	s.Use(rweb.RequestInfo) // Stats Middleware
 
 	s.Get("/", func(ctx rweb.Context) (err error) {
-		b, _, _ := element.Vars()
-
 		bob := Cat{Color: "yellow", Lazy: true}
 		phil := Dog{Color: "brown", Weight: 1.0}
 
+		b := element.NewBuilder()
 		b.Body().R(
 			b.H2().T("Rendering Animals"),
 			element.RenderComponents(b, bob),

--- a/examples/using_builder_funcs/main.go
+++ b/examples/using_builder_funcs/main.go
@@ -101,7 +101,7 @@ func rootHandler(c rweb.Context) error {
 	list2 := ListOfThings{Name: "More Items", Things: []string{"Item 1", "Item 2", "Item 3", "Item 4", "Item 5"}}
 	list3 := ListOfThings{Name: "Just Numbers", Numbers: []float64{17.0, 5.1, 98.7, 3.1415927}}
 
-	b, e, t := element.Vars()
+	b := element.B()
 
 	b.Html().R(
 		b.Head().R(


### PR DESCRIPTION
strings.Builder's underlying store is an []byte, yet it does not have a Bytes() output function :-\
bytes.NewBuffer offers compatibility, but with a Bytes() output method.
This will save us CPU cycles in cases where our input is already in []byte