### PR TITLE
Add Pretty() method to Builder for human-readable HTML formatting

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -58,3 +58,9 @@ func (b *Builder) Bytes() []byte {
 func (b *Builder) Reset() {
 	b.s.Reset()
 }
+
+// Pretty returns the HTML with pretty formatting (indentation and line breaks)
+// This is useful for debugging or when you need human-readable HTML output
+func (b *Builder) Pretty() string {
+	return PrettyHTML(b.s.String())
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -147,3 +147,96 @@ func TestBuilder_HtmlPage(t *testing.T) {
 		})
 	}
 }
+
+func generateList(b *Builder) any {
+	b.Ul().R(
+		b.Li().T("Item 1"),
+		b.Li().T("Item 2"),
+	)
+	return nil
+}
+
+func TestBuilder_Pretty(t *testing.T) {
+	tests := []struct {
+		name string
+		html func() *Builder
+		want string
+	}{
+		{
+			name: "Simple nested structure",
+			html: func() *Builder {
+				b := NewBuilder()
+				b.DivClass("container").R(
+					b.H2().T("Section 1"),
+					generateList(b),
+				)
+				return b
+			},
+			want: `<div class="container">
+  <h2>Section 1</h2>
+  <ul>
+    <li>Item 1</li>
+    <li>Item 2</li>
+  </ul>
+</div>
+`,
+		},
+		{
+			name: "Inline elements",
+			html: func() *Builder {
+				b := NewBuilder()
+				b.P().R(
+					b.Text("This is "),
+					b.Strong().T("bold"),
+					b.Text(" and "),
+					b.Em().T("italic"),
+					b.Text(" text."),
+				)
+				return b
+			},
+			want: `<p>This is <strong>bold</strong> and <em>italic</em> text.</p>
+`,
+		},
+		{
+			name: "Complex nested structure",
+			html: func() *Builder {
+				b := NewBuilder()
+				b.Html().R(
+					b.Head().R(
+						b.Title().T("Test Page"),
+					),
+					b.Body().R(
+						b.Div().R(
+							b.H1().T("Title"),
+							b.P().T("Paragraph"),
+						),
+					),
+				)
+				return b
+			},
+			want: `<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test Page</title>
+  </head>
+  <body>
+    <div>
+      <h1>Title</h1>
+      <p>Paragraph</p>
+    </div>
+  </body>
+</html>
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := tt.html()
+			got := b.Pretty()
+			if got != tt.want {
+				t.Errorf("Pretty() = \n%q\n, want \n%q", got, tt.want)
+			}
+		})
+	}
+}

--- a/helpers.go
+++ b/helpers.go
@@ -121,3 +121,141 @@ func ToOrdinal(n int) string {
 		return numStr + "th"
 	}
 }
+
+// inlineElements are HTML elements that should stay on the same line as their content
+var inlineElements = map[string]bool{
+	"a": true, "abbr": true, "b": true, "bdi": true, "bdo": true,
+	"cite": true, "code": true, "data": true, "dfn": true, "em": true,
+	"i": true, "kbd": true, "mark": true, "q": true, "s": true,
+	"samp": true, "small": true, "span": true, "strong": true, "sub": true,
+	"sup": true, "time": true, "u": true, "var": true,
+}
+
+// PrettyHTML formats HTML with proper indentation and line breaks
+// It parses the HTML and adds newlines and indentation for readability
+func PrettyHTML(html string) string {
+	if html == "" {
+		return ""
+	}
+
+	var result strings.Builder
+	var depth int
+	indent := "  " // 2 spaces per level
+	lastWasText := false
+	lastWasNewline := false // Track if we just wrote a newline
+
+	i := 0
+	for i < len(html) {
+		// Handle DOCTYPE, comments, and other special declarations
+		if strings.HasPrefix(html[i:], "<!") {
+			end := strings.Index(html[i:], ">")
+			if end != -1 {
+				result.WriteString(html[i : i+end+1])
+				result.WriteString("\n")
+				i += end + 1
+				lastWasText = false
+				lastWasNewline = true // We just wrote a newline
+				continue
+			}
+		}
+
+		// Handle opening tags
+		if html[i] == '<' && i+1 < len(html) && html[i+1] != '/' {
+			// Find the end of the tag
+			tagEnd := strings.Index(html[i:], ">")
+			if tagEnd == -1 {
+				result.WriteString(html[i:])
+				break
+			}
+
+			// Extract tag name
+			tagContent := html[i+1 : i+tagEnd]
+			spaceIdx := strings.IndexAny(tagContent, " \t\n")
+			tagName := tagContent
+			if spaceIdx != -1 {
+				tagName = tagContent[:spaceIdx]
+			}
+
+			isInline := inlineElements[strings.ToLower(tagName)]
+			isSelfClosing := singleTags[strings.ToLower(tagName)]
+
+			// Add newline and indentation for non-inline elements
+			if !isInline && i > 0 && !lastWasText {
+				// Only add newline if we didn't just write one
+				if !lastWasNewline {
+					result.WriteString("\n")
+				}
+				result.WriteString(strings.Repeat(indent, depth))
+			}
+
+			// Write the opening tag
+			result.WriteString(html[i : i+tagEnd+1])
+
+			// Increase depth for non-self-closing tags
+			if !isSelfClosing && !isInline {
+				depth++
+			}
+
+			i += tagEnd + 1
+			lastWasText = false
+			lastWasNewline = false
+			continue
+		}
+
+		// Handle closing tags
+		if html[i] == '<' && i+1 < len(html) && html[i+1] == '/' {
+			// Find the end of the tag
+			tagEnd := strings.Index(html[i:], ">")
+			if tagEnd == -1 {
+				result.WriteString(html[i:])
+				break
+			}
+
+			// Extract tag name
+			tagName := html[i+2 : i+tagEnd]
+
+			isInline := inlineElements[strings.ToLower(tagName)]
+
+			// Decrease depth for non-inline elements
+			if !isInline {
+				depth--
+			}
+
+			// Add indentation for non-inline elements (but not if last was text)
+			if !isInline && !lastWasText {
+				result.WriteString("\n")
+				result.WriteString(strings.Repeat(indent, depth))
+			}
+
+			// Write the closing tag
+			result.WriteString(html[i : i+tagEnd+1])
+
+			i += tagEnd + 1
+			lastWasText = false
+			lastWasNewline = false
+			continue
+		}
+
+		// Handle text content
+		textStart := i
+		for i < len(html) && html[i] != '<' {
+			i++
+		}
+
+		text := html[textStart:i]
+		// Skip text that is purely whitespace, but preserve actual text exactly as-is
+		if strings.TrimSpace(text) != "" {
+			// Write original text to preserve meaningful spaces
+			result.WriteString(text)
+			lastWasText = true
+			lastWasNewline = false
+		}
+	}
+
+	// Add final newline
+	if result.Len() > 0 {
+		result.WriteString("\n")
+	}
+
+	return result.String()
+}


### PR DESCRIPTION
This commit adds a Pretty() method to the Builder that formats HTML with proper indentation and line breaks for human readability.

Key features:
- Adds indentation (2 spaces per nesting level)
- Preserves inline elements (span, strong, em, etc.) on same line
- Handles block elements with proper newlines
- Preserves text content exactly as-is (including meaningful spaces)
- Correctly handles DOCTYPE and other special declarations

Implementation includes:
- Pretty() method on Builder (builder.go:64-66)
- PrettyHTML() helper function with full HTML parsing (helpers.go:134-252)
- Comprehensive test coverage (builder_test.go:151-241)

Use case: When you need pretty HTML for debugging or human viewing, call b.Pretty() instead of b.String().